### PR TITLE
Add and change a few supporting files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = "utf-8"
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{c,h}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_size = 8

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,23 @@
-.PHONY: lyra init docs test clean
+CFLAGS ?= -Wall -Wextra -Wpedantic -g -O1
+LDFLAGS ?= -g -O1
+LYRA_OBJS := lyra hm-node hm-ll hm ring em timer
 
-lyra: init bin/lyra
+.PHONY: all lyra init docs test clean
 
-init:
+all: lyra
+
+lyra: bin/lyra
+
+init: bin
+
+bin:
 	mkdir -p -- bin
 
-bin/lyra: bin/lyra.o bin/hm-node.o bin/hm-ll.o bin/hm.o bin/ring.o bin/em.o bin/timer.o
-	cc -std=c99 -Wall -Wextra -pedantic -g -O1 -o bin/lyra $^
+bin/lyra: $(addprefix bin/,$(addsuffix .o,$(LYRA_OBJS)))
+	cc $(LDFLAGS) -o bin/lyra $^
 
-bin/%.o: src/%.c
-	cc -std=c99 -Wall -Wextra -pedantic -g -O1 -I include -c -o $@ $^
+bin/%.o: src/%.c | init
+	cc $(CFLAGS) -std=c99 -I include -c -o $@ $<
 
 docs:
 	@printf "not implemented yet.\n" >&2
@@ -18,4 +26,4 @@ test:
 	@printf "not implemented yet.\n" >&2
 
 clean:
-	rm -rf -- bin/*
+	rm -r -- bin/*

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,6 @@
+-std=c99
+-Wall
+-Wextra
+-Wpedantic
+-I
+include


### PR DESCRIPTION
This PR includes:
* `.editorconfig` for cross-editor indentation consistency.
* `compile_flags.txt`. It's no `.clangd`, but at least now language servers that use it won't complain about not being able to find `<lyra/*.h>`.
* A slightly refactored Makefile. There's still lots to do with it if this project isn't going to use a more complex build system, but this should be somewhat more convenient to use.

I considered also adding in a `.clang-format` file and configuring it to match the current style of the project as much as possible, but that might be presumptuous of me.